### PR TITLE
Mark DaysSinceDomainCreation as nullable to fix exception ('The JSON …

### DIFF
--- a/src/EmailRep.NET/Models/QueryResponseDetails.cs
+++ b/src/EmailRep.NET/Models/QueryResponseDetails.cs
@@ -79,7 +79,7 @@ namespace EmailRep.NET.Models
         /// Days since the domain was created
         /// </summary>
         [J("days_since_domain_creation")]
-        public long DaysSinceDomainCreation { get; set; }
+        public long? DaysSinceDomainCreation { get; set; }
 
         /// <summary>
         /// Suspicious tld


### PR DESCRIPTION
…value could not be converted to System.Int64. Path: $.details.days_since_domain_creation | LineNumber: 17 | BytePositionInLine: 38.') with domains like @test.xyz